### PR TITLE
Use filter hook

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,24 +8,16 @@ Author: Matt Temple
 Author URI: http://www.mattytemple.com
 */
 
-// Hook our custom function into the 'pre_redirect' event
-yourls_add_action( 'pre_redirect', 'matt_skim' );
+// Hook our custom function into the 'redirect' filter
+yourls_add_filter( 'redirect', 'matt_skim', 10, 1 );
 
 // Our custom function that will be triggered when the event occurs
-function matt_skim( $args ) {
-        $url = $args[0];
-        $code = $args[1];
-        
+function matt_skim( $url ) {
         // Build URL
         $encoded = urlencode($url);
-		$skimurl = "http://YOURDOMAIN/?id=YOURID&xs=1&url="; //if you do not have a custom domain use redirect.skimlinks.com
-		$finalurl = $skimurl . $encoded;
-		
-		// Go
-		header("HTTP/1.1 301 Moved Permanently");
-		header("Location: $finalurl");
-		
-		// Now die so the normal flow of event is interrupted
-        die();
-      
+        $skimurl = "http://YOURDOMAIN/?id=YOURID&xs=1&url="; //if you do not have a custom domain use redirect.skimlinks.com
+        $finalurl = $skimurl . $encoded;
+        
+        // Return the skimmed URL
+        return $finalurl;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,6 @@ SETUP AND INSTALL
 You can test if it works by entering one of your short URLS on longurl.org
 and expanding the redirect details.
 
-This plugin requires YOURLS 1.5 (http://yourls.org) or higher and a
-Skimlinks account. If you don't have a Skimlinks account sign up
-here - http://matt.mx/skimlinks
+This plugin requires YOURLS 1.5 (http://yourls.org) or higher (tested
+against YOURLS SVN r728) and a Skimlinks account. If you don't have a
+Skimlinks account sign up here - http://matt.mx/skimlinks

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@ SETUP AND INSTALL
 
 1. Download the plugin
 2. open plugin.php in your chosen text editor
-3.change YOURURL to your Skimlinks custom URL or redirect.skimlinks.com if you don’t have a custom one.
+3. change YOURURL to your Skimlinks custom URL or redirect.skimlinks.com if you don’t have a custom one.
 4. change YOURID to your Skimlinks site ID (you can find this here, on your account setting page)
 5. save the file and upload the skimlinks folder to /user/plugins
 6. go to the plugins page in your YOURLS admin interface and activate the plugin
 
-You can test if it works by entering one of your short URLS on longurl.org and expnading the redirect details.
+You can test if it works by entering one of your short URLS on longurl.org and expanding the redirect details.
 
 This plugin requires YOURLS 1.5 (http://yourls.org) or higher and a Skimlinks account. If you don't have a Skimlinks account sign up here - http://matt.mx/skimlinks

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,17 @@ SETUP AND INSTALL
 
 1. Download the plugin
 2. open plugin.php in your chosen text editor
-3. change YOURURL to your Skimlinks custom URL or redirect.skimlinks.com if you don’t have a custom one.
-4. change YOURID to your Skimlinks site ID (you can find this here, on your account setting page)
+3. change YOURURL to your Skimlinks custom URL or redirect.skimlinks.com if
+   you don't have a custom one.
+4. change YOURID to your Skimlinks site ID (you can find this here, on your
+   account setting page)
 5. save the file and upload the skimlinks folder to /user/plugins
-6. go to the plugins page in your YOURLS admin interface and activate the plugin
+6. go to the plugins page in your YOURLS admin interface and activate the
+   plugin
 
-You can test if it works by entering one of your short URLS on longurl.org and expanding the redirect details.
+You can test if it works by entering one of your short URLS on longurl.org
+and expanding the redirect details.
 
-This plugin requires YOURLS 1.5 (http://yourls.org) or higher and a Skimlinks account. If you don't have a Skimlinks account sign up here - http://matt.mx/skimlinks
+This plugin requires YOURLS 1.5 (http://yourls.org) or higher and a
+Skimlinks account. If you don't have a Skimlinks account sign up
+here - http://matt.mx/skimlinks


### PR DESCRIPTION
Using the YOURLS filter system allows the JavaScript fallback to work instead of failing if `headers_sent()` is true.

I initially started rewriting the plugin to make sure click stats were recorded, but on closer code examination it looks like that all happens before the `pre_redirect` action. Nevertheless, I wasn't fond of the `die()` business.
